### PR TITLE
[docs] Fix comment typo in Ch3 generate_all_mutations 

### DIFF
--- a/notebooks/chapter_3_dna.ipynb
+++ b/notebooks/chapter_3_dna.ipynb
@@ -2046,7 +2046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "9da62290",
    "metadata": {},
    "outputs": [
@@ -2063,7 +2063,7 @@
     "  \"\"\"Generate all possible single base mutations of a one-hot DNA sequence.\"\"\"\n",
     "  mutated_sequences = []\n",
     "  for i in range(sequence.shape[0]):\n",
-    "    # At each position, one the four 'mutations' is the original base (no-op).\n",
+    "    # At each position, one of the four 'mutations' is the original base (no-op).\n",
     "    for j in range(4):\n",
     "      mutated_sequence = sequence.copy()\n",
     "      mutated_sequence[i] = np.zeros(4)\n",


### PR DESCRIPTION
fixed a typo I found in the notebook of chapter 3, where the comment in generate_all_mutations function was "one the four", which should've been "one of the four". 